### PR TITLE
Change localhost in etc/ice.config to "omero"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ADD 50-config.py 60-default-web-config.sh 98-cleanprevious.sh 99-run.sh /startup
 
 USER omero-web
 RUN mkdir /opt/omero/web/OMERO.web/var
+RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /opt/omero/web/OMERO.web/etc/ice.config
 
 EXPOSE 4080
 VOLUME ["/opt/omero/web/OMERO.web/var"]


### PR DESCRIPTION
Since the server will _never_ be running on localhost,
we change the etc/ice.config property to something that
is currently being used by a number of standard configurations
like docker-compose. If another value is desired, it will
need to be overwritten.