### PR TITLE
Add build & push to Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:centos7
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 LABEL org.openmicroscopy.release-date="unknown"
+LABEL org.openmicroscopy.commit="unknown"
 
 RUN mkdir /opt/setup
 WORKDIR /opt/setup

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,19 @@
 #   make VERSION=x.y.z BUILD=b
 #   git push origin x.y.z-b (or to snoopy for review)
 #
+# Build and release:
+#
+#   make VERSION=x.y.z REPO=snoopycrimecop
+#
 
 RELEASE = $(shell date)
 
-release:
+SHELL = bash
 
+REPO ?= openmicroscopy
+ORIGIN ?= origin
+
+release:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
@@ -28,3 +36,34 @@ else
 	git commit -a -m "Re-build $(BUILD) of OMERO_VERSION $(VERSION)"
 	git tag -s -m "Re-tag $(VERSION) with suffix $(BUILD)" $(VERSION)-$(BUILD)
 endif
+
+
+remote:
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
+
+ifndef BUILD
+	git push $(ORIGIN) $(VERSION)
+else
+	git push $(ORIGIN) $(VERSION)-$(BUILD)
+endif
+
+
+build:
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
+	docker build -t $(REPO)/omero-web:latest .
+	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$(VERSION)
+	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
+	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$$MAJOR_MINOR
+
+push:
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
+	docker push $(REPO)/omero-web:latest
+	docker push $(REPO)/omero-web:$(VERSION)
+	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
+	docker push $(REPO)/omero-web:$$MAJOR_MINOR

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,3 @@
-#
-# Usage:
-#
-#   make VERSION=x.y.z
-#   git push origin x.y.z (or to snoopy for review)
-#
-# To trigger another build, use:
-#
-#   make VERSION=x.y.z BUILD=b
-#   git push origin x.y.z-b (or to snoopy for review)
-#
-# Build and release:
-#
-#   make VERSION=x.y.z REPO=snoopycrimecop
-#
-
 RELEASE = $(shell date)
 COMMIT = $(shell git rev-parse HEAD || echo -n NOTGIT)
 
@@ -22,7 +6,23 @@ SHELL = bash
 REPO ?= openmicroscopy
 ORIGIN ?= origin
 
-release:
+usage:
+	@echo "Usage:"
+	@echo " "
+	@echo "  make VERSION=x.y.z tag                            #   Update Dockerfile, commit and tag"
+	@echo "  make VERSION=x.y.z BUILD=1 tag                    #   Re-tag, e.g. when a new upstream is released"
+	@echo " "
+	@echo "  # Release Candidate"
+	@echo "  make VERSION=x.y.z ORIGIN=snoopycrimecop remote   #   Push to another git remote"
+	@echo "  make VERSION=x.y.z REPO=snoopycrimecop build      #   Build and tag images for another hub account"
+	@echo "  make VERSION=x.y.z REPO=snoopycrimecop push       #   Push images to another hub account"
+	@echo " "
+	@echo "  # Release"
+	@echo "  make VERSION=x.y.z remote                         #   Push to $(ORIGIN)"
+	@echo "  make VERSION=x.y.z build                          #   Build and tag images for $(REPO) hub repo"
+	@echo "  make VERSION=x.y.z push                           #   Push images to $(REPO) hub repo"
+
+tag:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 #
 
 RELEASE = $(shell date)
+COMMIT = $(shell git rev-parse HEAD || echo -n NOTGIT)
 
 SHELL = bash
 
@@ -28,6 +29,7 @@ endif
 
 	perl -i -pe 's/OMERO_VERSION=(\S+)/OMERO_VERSION=$(VERSION)/' Dockerfile
 	perl -i -pe 's/(org.openmicroscopy.release-date=)"([^"]+)"/$$1"$(RELEASE)"/' Dockerfile
+	perl -i -pe 's/(org.openmicroscopy.commit=)"([^"]+)"/$$1"$(COMMIT)"/' Dockerfile
 
 ifndef BUILD
 	git commit -a -m "Bump OMERO_VERSION to $(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ endif
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$$MAJOR_MINOR
 
+	docker build -t $(REPO)/omero-web-standalone:latest standalone
+	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)
+	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
+	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$$MAJOR_MINOR
+
 push:
 ifndef VERSION
 	$(error VERSION is undefined)
@@ -67,3 +72,8 @@ endif
 	docker push $(REPO)/omero-web:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker push $(REPO)/omero-web:$$MAJOR_MINOR
+
+	docker push $(REPO)/omero-web-standalone:latest
+	docker push $(REPO)/omero-web-standalone:$(VERSION)
+	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
+	docker push $(REPO)/omero-web-standalone:$$MAJOR_MINOR

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ usage:
 	@echo "  make VERSION=x.y.z build                          #   Build and tag images for $(REPO) hub repo"
 	@echo "  make VERSION=x.y.z push                           #   Push images to $(REPO) hub repo"
 
+
 tag:
 ifndef VERSION
 	$(error VERSION is undefined)
@@ -56,26 +57,37 @@ build:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
+ifndef BUILD
+	$(eval BUILD=0)
+endif
 	docker build -t $(REPO)/omero-web:latest .
+	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$(VERSION)-$(BUILD)
 	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$$MAJOR_MINOR
 
 	docker build -t $(REPO)/omero-web-standalone:latest standalone
+	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)-$(BUILD)
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$$MAJOR_MINOR
+
 
 push:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
+ifndef BUILD
+	$(eval BUILD=0)
+endif
 	docker push $(REPO)/omero-web:latest
+	docker push $(REPO)/omero-web:$(VERSION)-$(BUILD)
 	docker push $(REPO)/omero-web:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker push $(REPO)/omero-web:$$MAJOR_MINOR
 
 	docker push $(REPO)/omero-web-standalone:latest
+	docker push $(REPO)/omero-web-standalone:$(VERSION)-$(BUILD)
 	docker push $(REPO)/omero-web-standalone:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker push $(REPO)/omero-web-standalone:$$MAJOR_MINOR

--- a/Makefile
+++ b/Makefile
@@ -9,21 +9,21 @@ ORIGIN ?= origin
 usage:
 	@echo "Usage:"
 	@echo " "
-	@echo "  make VERSION=x.y.z tag                            #   Update Dockerfile, commit and tag"
-	@echo "  make VERSION=x.y.z BUILD=1 tag                    #   Re-tag, e.g. when a new upstream is released"
+	@echo "  make VERSION=x.y.z git-tag                          #   Update Dockerfile, commit and tag"
+	@echo "  make VERSION=x.y.z BUILD=1 git-tag                  #   Re-tag, e.g. when a new upstream is released"
 	@echo " "
 	@echo "  # Release Candidate"
-	@echo "  make VERSION=x.y.z ORIGIN=snoopycrimecop remote   #   Push to another git remote"
-	@echo "  make VERSION=x.y.z REPO=snoopycrimecop build      #   Build and tag images for another hub account"
-	@echo "  make VERSION=x.y.z REPO=snoopycrimecop push       #   Push images to another hub account"
+	@echo "  make VERSION=x.y.z ORIGIN=snoopycrimecop git-push   #   Push to another git remote"
+	@echo "  make VERSION=x.y.z REPO=snoopycrimecop docker-build #   Build and tag images for another hub account"
+	@echo "  make VERSION=x.y.z REPO=snoopycrimecop docker-push  #   Push images to another hub account"
 	@echo " "
 	@echo "  # Release"
-	@echo "  make VERSION=x.y.z remote                         #   Push to $(ORIGIN)"
-	@echo "  make VERSION=x.y.z build                          #   Build and tag images for $(REPO) hub repo"
-	@echo "  make VERSION=x.y.z push                           #   Push images to $(REPO) hub repo"
+	@echo "  make VERSION=x.y.z git-push                         #   Push to $(ORIGIN)"
+	@echo "  make VERSION=x.y.z docker-build                     #   Build and tag images for $(REPO) hub repo"
+	@echo "  make VERSION=x.y.z docker-push                      #   Push images to $(REPO) hub repo"
 
 
-tag:
+git-tag:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
@@ -41,7 +41,7 @@ else
 endif
 
 
-remote:
+git-push:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
@@ -53,7 +53,7 @@ else
 endif
 
 
-build:
+docker-build:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
@@ -73,7 +73,7 @@ endif
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$$MAJOR_MINOR
 
 
-push:
+docker-push:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif


### PR DESCRIPTION
To no longer depending solely on automated builds, the makefile
can now build the server and re-tag with all the appropriate versions
before pushing to Docker Hub.