### PR TITLE
Update build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
   - docker
 
 script:
-  - ./test.sh
+  - ./build.sh

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ endif
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$$MAJOR_MINOR
 
+	perl -i -pe 's%FROM\s.+%FROM $(REPO)/omero-web:latest%' standalone/Dockerfile
+
 	docker build -t $(REPO)/omero-web-standalone:latest standalone
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)-$(BUILD)
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 ifndef BUILD
 	$(eval BUILD=0)
 endif
-	docker build -t $(REPO)/omero-web:latest .
+	docker build $(BUILDARGS) -t $(REPO)/omero-web:latest .
 	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$(VERSION)-$(BUILD)
 	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,7 @@ endif
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$$MAJOR_MINOR
 
-	perl -i -pe 's%FROM\s.+%FROM $(REPO)/omero-web:latest%' standalone/Dockerfile
-
-	docker build -t $(REPO)/omero-web-standalone:latest standalone
+	docker build --build-arg=PARENT_IMAGE=$(REPO)/omero-web:$(VERSION) -t $(REPO)/omero-web-standalone:latest standalone
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)-$(BUILD)
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\

--- a/README.md
+++ b/README.md
@@ -72,3 +72,20 @@ Exposed ports
 -------------
 
 - 4080
+
+
+Development
+-----------
+
+You can use this repository to build a custom image for testing development builds of OMERO.web.
+For example, to install OMERO.web from the `OMERO-build` CI job:
+
+    make VERSION=test REPO=test BUILDARGS="\
+        --build-arg OMEGO_ADDITIONAL_ARGS=--ci=https://web-proxy.openmicroscopy.org/west-ci/ \
+        --build-arg=OMERO_VERSION=OMERO-build" docker-build
+
+    docker run -d --name test-web \
+        -e CONFIG_omero_web_server__list='[["eel.openmicroscopy.org", 4064, "eel"]]' \
+        -e CONFIG_omero_web_debug=true \
+        -p 4080:4080 \
+        test/omero-web-standalone:latest

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,14 @@
 set -e
 set -u
 
-PREFIX=test
-IMAGE=omero-web:$PREFIX
-STANDLONE=omero-web-standalone:$PREFIX
+PREFIX=${TRAVIS_BRANCH:-test}
+if [ -n "${DOCKER_USERNAME:-}" -a -z "${REPO:-}" ]; then
+    REPO="${DOCKER_USERNAME}"
+else
+    REPO="${REPO:-test}"
+fi
+IMAGE=$REPO/omero-web:$PREFIX
+STANDLONE=$REPO/omero-web-standalone:$PREFIX
 
 CLEAN=${CLEAN:-y}
 
@@ -19,8 +24,8 @@ fi
 
 cleanup || true
 
+make VERSION="$PREFIX" REPO="$REPO" docker-build
 
-docker build -t $IMAGE .
 docker run -d --name $PREFIX-web \
     -e CONFIG_omero_web_server__list='[["omero.example.org", 4064, "test-omero"]]' \
     -e CONFIG_omero_web_debug=true \
@@ -31,9 +36,6 @@ bash test_getweb.sh
 
 # Standalone image
 cleanup
-sed -i "s/FROM .*/FROM $IMAGE/" standalone/Dockerfile
-
-docker build -t $STANDLONE standalone/
 docker run -d --name $PREFIX-web \
     -e CONFIG_omero_web_server__list='[["omero.example.org", 4064, "test-omero"]]' \
     -e CONFIG_omero_web_debug=true \
@@ -41,3 +43,10 @@ docker run -d --name $PREFIX-web \
     $STANDLONE
 
 bash test_getweb.sh
+
+if [ -n "${DOCKER_USERNAME:-}" ]; then
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    make  VERSION="$PREFIX" REPO="$REPO" docker-push
+else
+    echo Docker push disabled
+fi

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-PREFIX=${TRAVIS_BRANCH:-test}
+export PREFIX=${TRAVIS_BRANCH:-test}
 if [ -n "${DOCKER_USERNAME:-}" -a -z "${REPO:-}" ]; then
     REPO="${DOCKER_USERNAME}"
 else

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -1,4 +1,5 @@
-FROM openmicroscopy/omero-web:latest
+ARG PARENT_IMAGE=openmicroscopy/omero-web:latest
+FROM ${PARENT_IMAGE}
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 USER root

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 USER root
 
 RUN /opt/omero/web/venv/bin/pip install \
-        django-cors-headers \
+        django-cors-headers==2.4.1 \
         omero-figure \
         omero-fpbioimage \
         omero-iviewer \

--- a/test_getweb.sh
+++ b/test_getweb.sh
@@ -4,9 +4,11 @@ set -e
 set -u
 set -x
 
+PREFIX=${PREFIX:-test}
+
 # Wait up to 2 mins
 i=0
-while ! docker logs test-web 2>&1 | grep 'Listening at: http://0.0.0.0:4080'; do
+while ! docker logs "$PREFIX-web" 2>&1 | grep 'Listening at: http://0.0.0.0:4080'; do
     i=$(($i+1))
     if [ $i -ge 24 ]; then
         echo "$(date) - OMERO.web still not listening, giving up"


### PR DESCRIPTION
- Fixes the Makefile so the standalone image is always built from the matching non-standalone image, e.g. `make docker-build` should work as expected, previously the standalone image ignored the local one.
- Updates the test script so in future it could be used to push to Travis. At present the OMERO.web Docker release process is completely manual since automated builds don't allow multiple images.
- Adds the django-cors-header fix from https://github.com/IDR/deployment/pull/169

This should make it easier to test OMERO.web Docker related PRs. For example https://github.com/openmicroscopy/openmicroscopy/pull/5948#issuecomment-463558970 could be tested locally by building the standalone image with a CI artifact:

```
make VERSION=test REPO=test BUILDARGS="\
    --build-arg OMEGO_ADDITIONAL_ARGS=--ci=https://web-proxy.openmicroscopy.org/west-ci/ \
    --build-arg=OMERO_VERSION=OMERO-build" docker-build

docker run -d --name test-web \
    -e CONFIG_omero_web_server__list='[["eel.openmicroscopy.org", 4064, "eel"]]' \
    -e CONFIG_omero_web_debug=true \
    -p 4080:4080 \
    test/omero-web-standalone:latest

```


