### PR TITLE
Test updated build with docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+REPO=test
+PREFIX=test
+SERVERS=[["demo.openmicroscopy.org", 4064, "OMERO"]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.3"
+#
+# Compose for the development of this docker image
+#
+services:
+
+  parent:
+    image: ${REPO}/omero-web:${PREFIX}
+    build:
+      context: .
+      args:
+        - OMEGO_ADDITIONAL_ARGS="--ci=https://merge-ci.openmicroscopy.org/jenkins/"
+        - OMERO_VERSION="OMERO-build"
+    entrypoint: "true"
+
+  web:
+    image: ${REPO}/omero-web-standalone:${PREFIX}
+    build:
+      context: standalone
+      args:
+        - PARENT_IMAGE=${REPO}/omero-web:${PREFIX}
+    environment:
+      - CONFIG_omero_web_debug="true"
+      - CONFIG_omero_web_server__list=${SERVERS}
+    ports:
+      - 4080:4080


### PR DESCRIPTION
Beyond just using make for building a set of paired
omero-web and omero-web-standalone images, this allows
building within a self-contained docker-compose.yml.

see: https://github.com/openmicroscopy/omero-web-docker/pull/28

Questions:

 - [ ] default server to point at
 - [ ] whether or not to include a server & db container

cc: @manics @will-moore 